### PR TITLE
Add missing plugs and snapcraft-preload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ Packages the WoTT Agent into a Snap.
 ## Installing
 
 ```
-$ snap install wott-agent
+$ sudo snap install wott-agent
+```
+The "unsafe" interfaces needed by this snap are not auto-connected (may change in the future). Manual connection is needed:
+```
+$ sudo snap connect wott-agent:network-control :network-control
+$ sudo snap connect wott-agent:network-setup-control :network-setup-control
+$ sudo snap connect wott-agent:process-control :process-control
+$ sudo snap connect wott-agent:system-observe :system-observe
+$ sudo snap connect wott-agent:firewall-control :firewall-control
+$ sudo snap connect wott-agent:account-control :account-control
+$ sudo snap connect wott-agent:log-observe :log-observe
 ```
 
 ## Building (locally)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: wott-agent
-version: '0.1.5.0-19'
+version: '0.1.5.0-26'
 summary: Web of Trusted Things agent.
 description: |
   tl;dr - WoTT Agent is the Let's Encrypt for IoT.
@@ -9,13 +9,20 @@ base: core18
 
 apps:
   daemon:
-    command: wott-agent daemon
+    command: bin/snapcraft-preload $SNAP/bin/wott-agent daemon
     daemon: simple
     plugs:
       - firewall-control
       - hardware-observe
       - network
+      - network-setup-control
+      - network-bind
       - network-observe
+      - network-control
+      - process-control
+      - system-observe
+      - account-control
+      - log-observe
       - tpm
     environment:
       XTABLES_LIBDIR: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/xtables
@@ -26,8 +33,15 @@ apps:
   wott-agent:
     command: wott-agent
     plugs:
+      - firewall-control
+      - hardware-observe
       - network
       - network-observe
+      - network-control
+      - system-observe
+      - account-control
+      - log-observe
+      - tpm
     environment:
       XTABLES_LIBDIR: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/xtables
       CONFIG_PATH: $SNAP_DATA
@@ -67,6 +81,19 @@ slots:
       - $SNAP_DATA
 
 parts:
+  snapcraft-preload:
+    source: https://github.com/diddlesnaps/snapcraft-preload.git
+    source-type: git
+    source-branch: semaphore-support
+    plugin: cmake
+    build-packages:
+      - on amd64:
+        - gcc-multilib
+        - g++-multilib
+      - else:
+        - gcc
+        - g++
+
   wott-agent:
     plugin: python
     python-version: python3

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -121,6 +121,8 @@ parts:
     build-packages:
       - build-essential
       - libltdl-dev
+    stage-packages:
+      - libltdl7
 
   tools:
     source: bin/


### PR DESCRIPTION
The [source branch](https://github.com/WoTTsecurity/agent-snap/pull/9/files#diff-184032a532406b07009403e26f4fc62fR100-R104) must be reverted back to the original after approval of this PR and **before merge**.

Last builds are available at https://code.launchpad.net/~artem-martynovich/+snap/wott-agent.